### PR TITLE
Removing need for including lv_conf.h in yaml conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,22 @@
 *.out
 *.app
 
+
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
 /.esphome/
-/secrets.yaml
 /.vscode/
+
+**/.pioenvs/
+**/.piolibdeps/
+
+**/lib/
+**/src/
+**/platformio.ini
+**/partitions.csv
+
+/secrets.yaml
+/esphome-lvgl/
+**/*.pyc
+**/secrets.yaml

--- a/README.md
+++ b/README.md
@@ -84,19 +84,6 @@ external_components:
 
 See [ESPHome external components documentation](https://esphome.io/components/external_components.html) for more information.
 
-One wrinkle that hasn't been ironed out yet is the include path for `lv_conf.h` file. For now it _needs to be_ provided in the `esphome` section of the configuration file.
-
-```yaml
-esphome:
-  name: esphome-lvgl
-  includes:
-    - esphome/components/gui/lv_conf.h
-```
-
-> **Warning**
-> 
-> If `lv_conf.h` is not included, build errors will happen!
-
 After that, `esphome-gui` is used in a usual fashion:
 
 ```yaml

--- a/esphome/components/gui/__init__.py
+++ b/esphome/components/gui/__init__.py
@@ -1,7 +1,10 @@
+import os
 import re
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.core as core
+import esphome.core.config as cfg
 from esphome.const import CONF_DIMENSIONS, CONF_ID, CONF_POSITION, CONF_TYPE
 
 from esphome.components import display, switch
@@ -99,7 +102,7 @@ CONFIG_SCHEMA = cv.All(
 # of lv_conf_internal.h. Internal config is under:
 # .esphome/build/<project_name>/.piolibdeps/<project_name>/lvgl/src
 #
-# lvgl.h gets copied to:
+# lv_conf.h gets copied to:
 # .esphome/build/<project_name>/src
 #
 # So LV_CONF_PATH should point three levels up and into the src directory.
@@ -130,6 +133,14 @@ async def gui_items_to_code(config):
 
 
 async def to_code(config):
+    whereami = os.path.realpath(__file__)
+    component_dir = os.path.dirname(whereami)
+
+    # Make sure that lv_conf.h gets copied to the src directory, along with
+    # other generated files.
+    lv_conf_path = os.path.join(component_dir, 'lv_conf.h')
+    core.CORE.add_job(cfg.add_includes, [lv_conf_path])
+    
     cg.add_library("https://github.com/lvgl/lvgl.git", None)
     cg.add_platformio_option("build_flags", LVGL_BUILD_FLAGS)
 

--- a/esphome/components/gui/gui_objects.cpp
+++ b/esphome/components/gui/gui_objects.cpp
@@ -51,15 +51,17 @@ void GuiLabel::dump_config() {
   ESP_LOGCONFIG(TAG, "Label created at (%i, %i)", this->x_, this->y_);
 }
 
-void GuiLabel::print(const char* text) {
+void GuiLabel::print(const char *text) {
   this->set_text(text);
   this->update();
 }
-void GuiLabel::print(int x, int y, const char* text) {
+void GuiLabel::print(int x, int y, const char *text) {
   this->set_text(text);
   this->set_coords(x, y);
   this->update();
 }
+
+#ifdef USE_TIME
 void GuiLabel::strftime(const char *format, time::ESPTime time) {
   char buffer[64] = {0};
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
@@ -76,6 +78,7 @@ void GuiLabel::strftime(int x, int y, const char *format, time::ESPTime time) {
   this->strftime(format, time);
   this->update();
 }
+#endif
 
 #ifdef USE_CHECKBOX
 void GuiCheckbox::setup() {

--- a/esphome/components/gui/gui_objects.h
+++ b/esphome/components/gui/gui_objects.h
@@ -39,8 +39,10 @@ class GuiLabel : public GuiObject, public Component {
 
   void print(const char* text);
   void print(int x, int y, const char* text);
+#ifdef USE_TIME
   void strftime(const char* format, time::ESPTime time);
   void strftime(int x, int y, const char* format, time::ESPTime time);
+#endif
 };
 
 #ifdef USE_CHECKBOX


### PR DESCRIPTION
This PR removes the need to use `includes` statement in the YAML configuration file to include `lv_conf.h` header along with the genrated sources. `esphome-gui` component now does that automatically.
Also, minor formatting changes and fixes a compilation issue when `time` component is not used along with `esphome-gui`.