### PR TITLE
Changing code for stable lvgl and esphome

### DIFF
--- a/docs/examples/lilygo-tembed-clock.yaml
+++ b/docs/examples/lilygo-tembed-clock.yaml
@@ -1,7 +1,5 @@
 esphome:
   name: esphome-gui-lilygo-tembed-clock
-  includes:
-    - esphome/components/gui/lv_conf.h
   platformio_options:
     # CDC_ON_BOOT enables early access to serial console;
     # this way it can print all the core dumps etc.
@@ -22,7 +20,7 @@ esphome:
     upload_protocol: esptool
     monitor_filters: esp32_exception_decoder
   on_boot:
-    priority: 600
+    priority: 250
     then:
       - lambda: |-
           id(disp).enable();
@@ -80,6 +78,7 @@ display:
 
 time:
   - platform: homeassistant
+    timezone: CET-1CEST,M3.5.0,M10.5.0/3
     id: home_time
     on_time:
       - seconds: 0
@@ -110,6 +109,7 @@ gui:
       position: 0,0
       dimensions: 170x25
       switch_id: power_on
+      text: "Power On"
 
 switch:
   - platform: gpio

--- a/esphome/components/gui/__init__.py
+++ b/esphome/components/gui/__init__.py
@@ -110,7 +110,7 @@ CONFIG_SCHEMA = cv.All(
 # here, esphome's build picks it up.
 LVGL_BUILD_FLAGS = [
     "-D LV_USE_LOG=1",
-    "-D LV_USE_DEV_VERSION=1",
+    "-D LV_USE_DEV_VERSION=0",
 ]
 
 
@@ -137,12 +137,12 @@ async def to_code(config):
 
     # Make sure that lv_conf.h gets copied to the src directory, along with
     # other generated files.
-    lv_conf_path = os.path.join(component_dir, 'lv_conf.h')
+    lv_conf_path = os.path.join(component_dir, "lv_conf.h")
     core.CORE.add_job(cfg.add_includes, [lv_conf_path])
- 
+
     cg.add_library("lvgl/lvgl", "^8.3")
     cg.add_platformio_option("build_flags", LVGL_BUILD_FLAGS)
-    cg.add_platformio_option("build_flags", ["-D LV_CONF_PATH='"+lv_conf_path+"'"])
+    cg.add_platformio_option("build_flags", ["-D LV_CONF_PATH='" + lv_conf_path + "'"])
     gui = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(gui, config)
 
@@ -150,6 +150,7 @@ async def to_code(config):
 
     cg.add(gui.set_display(disp))
     cg.add_define("USE_GUI")
+    cg.add_define("USE_LVGL_PROD")
 
     if CONF_ITEMS in config:
         await gui_items_to_code(config[CONF_ITEMS])

--- a/esphome/components/gui/gui.cpp
+++ b/esphome/components/gui/gui.cpp
@@ -1,7 +1,5 @@
 #include "gui.h"
 
-#include <string_view>
-
 namespace esphome {
 namespace gui {
 
@@ -10,62 +8,38 @@ static const char *const TAG = "gui";
 using namespace display;
 
 namespace lv_shim {
-// static lv_disp_drv_t lv_disp_drv; // lvgl 8.3.4
-// static lv_disp_draw_buf_t lv_disp_buf; // lvgl 8.3.4
-static lv_disp_t *lv_disp{nullptr};
+static lv_disp_drv_t lv_disp_drv;
+static lv_disp_draw_buf_t lv_disp_buf;
+
 static DisplayBuffer *disp_buf{nullptr};
 
 #if LV_USE_LOG
-static void lv_esp_log(lv_log_level_t level, const char *buf) {
-  switch (level) {
-    case LV_LOG_LEVEL_TRACE:
-      ESP_LOGV("LVGL", buf);
-      break;
-    case LV_LOG_LEVEL_INFO:
-      ESP_LOGI("LVGL", buf);
-      break;
-    case LV_LOG_LEVEL_WARN:
-      ESP_LOGW("LVGL", buf);
-      break;
-    case LV_LOG_LEVEL_ERROR:
-      ESP_LOGE("LVGL", buf);
-      break;
-    case LV_LOG_LEVEL_USER:
-      ESP_LOGD("LVGL", buf);
-      break;
-    case LV_LOG_LEVEL_NONE:
-    default:
-      break;
-  }
+static void lv_esp_log(const char *buf) {
+  ESP_LOGV("LVGL", buf);
 }
 #endif
 
-static void lv_drv_refresh(lv_disp_t *disp, const lv_area_t *area,
+static void lv_drv_refresh(lv_disp_drv_t *disp_drv, const lv_area_t *area,
                            lv_color_t *buf) {
   lv_shim::disp_buf->update();
-  lv_disp_flush_ready(disp);
+  lv_disp_flush_ready(disp_drv);
 }
 
-lv_disp_t *init_lv_drv(DisplayBuffer *db, lv_disp_rotation_t rotation) {
+lv_disp_t *init_lv_drv(DisplayBuffer *db, lv_disp_rot_t rotation) {
   lv_shim::disp_buf = db;
-
   uint8_t *buf = db->get_buffer();
+
   // hacky hack as there's no consistency in how DisplayBuffer specializations
   // implement get_buffer_length method (if at all)
   uint32_t len = db->get_buffer_length_();
+  ESP_LOGV("GUI", "[init_lv_drv] Memory buffer length %u", len);
 
   lv_init();
-  lv_disp = lv_disp_create(db->get_width(), db->get_height());
-  lv_disp_set_draw_buffers(lv_disp, buf, NULL, len, LV_DISP_RENDER_MODE_DIRECT);
-  lv_disp_set_flush_cb(lv_disp, lv_drv_refresh);
-  lv_disp_set_rotation(lv_disp, rotation, false);
-  lv_obj_set_style_bg_color(lv_scr_act(), lv_color_hex(0x000000), LV_PART_MAIN);
 
 #if LV_USE_LOG
   lv_log_register_print_cb(lv_esp_log);
 #endif
 
-#if USE_LVGL_PROD
   lv_disp_draw_buf_init(&lv_disp_buf, buf, NULL, len);
   lv_disp_drv_init(&lv_disp_drv);
   lv_disp_drv.hor_res = disp_buf->get_width();
@@ -76,9 +50,9 @@ lv_disp_t *init_lv_drv(DisplayBuffer *db, lv_disp_rotation_t rotation) {
   lv_disp_drv.draw_buf = &lv_disp_buf;
   lv_disp_drv.sw_rotate = true;
   lv_disp_t *disp = lv_disp_drv_register(&lv_disp_drv);
+  
+  lv_obj_set_style_bg_color(lv_scr_act(), lv_color_hex(0x000000), LV_PART_MAIN);
   return disp;
-#endif
-  return lv_disp;
 }
 }  // namespace lv_shim
 
@@ -86,33 +60,33 @@ void GuiComponent::setup() {
   // Register this instance of the GUI component with the lvgl driver
   DisplayBuffer *disp_buf = this->display_;
   this->lv_disp_ = lv_shim::init_lv_drv(disp_buf, this->get_lv_rotation());
-  // this->high_freq_.start();
+  this->high_freq_.start();
 }
 
 void GuiComponent::loop() { lv_timer_handler(); }
 
 void GuiComponent::dump_config() {
   auto drv = this->lv_disp_;
-  ESP_LOGCONFIG(TAG, "LVGL driver.hor_res: %i", drv->hor_res);
-  ESP_LOGCONFIG(TAG, "LVGL driver.ver_res: %i", drv->ver_res);
-  ESP_LOGCONFIG(TAG, "LVGL driver.rotation: %i", drv->rotation);
+  ESP_LOGCONFIG(TAG, "LVGL driver.hor_res: %i", drv->driver->hor_res);
+  ESP_LOGCONFIG(TAG, "LVGL driver.ver_res: %i", drv->driver->ver_res);
+  ESP_LOGCONFIG(TAG, "LVGL driver.rotation: %i", drv->driver->rotated);
 }
 
-lv_disp_rotation_t GuiComponent::get_lv_rotation() {
+lv_disp_rot_t GuiComponent::get_lv_rotation() {
   if (this->display_ != nullptr) {
     auto rot = this->display_->get_rotation();
     switch (rot) {
       case DISPLAY_ROTATION_0_DEGREES:
-        return LV_DISP_ROTATION_0;
+        return LV_DISP_ROT_NONE;
       case DISPLAY_ROTATION_90_DEGREES:
-        return LV_DISP_ROTATION_90;
+        return LV_DISP_ROT_90;
       case DISPLAY_ROTATION_180_DEGREES:
-        return LV_DISP_ROTATION_180;
+        return LV_DISP_ROT_180;
       case DISPLAY_ROTATION_270_DEGREES:
-        return LV_DISP_ROTATION_270;
+        return LV_DISP_ROT_270;
     }
   }
-  return LV_DISP_ROTATION_0;
+  return LV_DISP_ROT_NONE;
 }
 
 }  // namespace gui

--- a/esphome/components/gui/gui.h
+++ b/esphome/components/gui/gui.h
@@ -30,7 +30,7 @@ class GuiComponent : public Component {
   DisplayBuffer *display_{nullptr};
   lv_disp_t *lv_disp_{nullptr};
 
-  lv_disp_rotation_t get_lv_rotation();
+  lv_disp_rot_t get_lv_rotation();
 
  private:
   HighFrequencyLoopRequester high_freq_;

--- a/esphome/components/gui/gui_objects.h
+++ b/esphome/components/gui/gui_objects.h
@@ -39,9 +39,9 @@ class GuiLabel : public GuiObject, public Component {
 
   void print(const char* text);
   void print(int x, int y, const char* text);
-#ifdef USE_TIMEX
-  void strftime(const char* format, time::ESPTime time);
-  void strftime(int x, int y, const char* format, time::ESPTime time);
+#ifdef USE_TIME
+  void strftime(const char* format, ESPTime time);
+  void strftime(int x, int y, const char* format, ESPTime time);
 #endif
 };
 
@@ -49,6 +49,7 @@ class GuiLabel : public GuiObject, public Component {
 class GuiCheckbox : public GuiObject, public Component {
  protected:
   switch_::Switch* switch_;
+  bool switch_state;
 
  public:
   void setup() override;
@@ -59,7 +60,12 @@ class GuiCheckbox : public GuiObject, public Component {
   }
 
   void set_switch(switch_::Switch* sw) { this->switch_ = sw; }
-  static void event_callback(lv_event_t* event);
+  // Callback for events generated from the UI (e.g., someone clicked the UI,
+  // and now need to update switch value)
+  static void gui_event_callback(lv_event_t* event);
+  // Callback for events generated from the switch (e.g., someone changed switch
+  // via Home Assistant and now need to update GUI)
+  static void switch_event_callback(bool state);
 };
 #endif
 

--- a/esphome/components/gui/lv_conf.h
+++ b/esphome/components/gui/lv_conf.h
@@ -1,47 +1,49 @@
 /**
  * @file lv_conf.h
- * Configuration file for v9.0.0-dev
- */
-
-/*
- * Copy this file as `lv_conf.h`
- * 1. simply next to the `lvgl` folder
- * 2. or any other places and
- *    - define `LV_CONF_INCLUDE_SIMPLE`
- *    - add the path as include path
+ * Configuration file for v8.3.9
  */
 
 /* clang-format off */
 #if 1 /*Set it to "1" to enable content*/
+/* Pragma here may be useful when debugging and not sure if build is picking up the right lv_conf.h*/
+/*#pragma message("This is custom lv_conf for lvgl 8.3.9")*/
 
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
 #include <stdint.h>
 
-#define LV_USE_DEV_VERSION 1
-
 /*====================
    COLOR SETTINGS
  *====================*/
 
-/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 24 (RGB888), 32 (ARGB8888)*/
+/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
 #define LV_COLOR_DEPTH 16
 
-#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)
+/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
+#define LV_COLOR_16_SWAP 0
+
+/*Enable features to draw on transparent background.
+ *It's required if opa, and transform_* style properties are used.
+ *Can be also used if the UI is above another layer, e.g. an OSD menu or video player.*/
+#define LV_COLOR_SCREEN_TRANSP 0
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS 0
+
+/*Images pixels with this color will not be drawn if they are chroma keyed)*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
 
 /*=========================
-   STDLIB WRAPPER SETTINGS
+   MEMORY SETTINGS
  *=========================*/
 
-/*Enable and configure the built-in memory manager*/
-#define LV_USE_BUILTIN_MALLOC 1
-#if LV_USE_BUILTIN_MALLOC
-    /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
+/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
+#define LV_MEM_CUSTOM 0
+#if LV_MEM_CUSTOM == 0
+    /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
     #define LV_MEM_SIZE (64U * 1024U)          /*[bytes]*/
-
-    /*Size of the memory expand for `lv_malloc()` in bytes*/
-    #define LV_MEM_POOL_EXPAND_SIZE 0
 
     /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
     #define LV_MEM_ADR 0     /*0: unused*/
@@ -50,42 +52,30 @@
         #undef LV_MEM_POOL_INCLUDE
         #undef LV_MEM_POOL_ALLOC
     #endif
-#endif  /*LV_USE_BUILTIN_MALLOC*/
 
-/*Enable lv_memcpy_builtin, lv_memset_builtin, lv_strlen_builtin, lv_strncpy_builtin, lv_strcpy_builtin*/
-#define LV_USE_BUILTIN_MEMCPY 1
+#else       /*LV_MEM_CUSTOM*/
+    #define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+    #define LV_MEM_CUSTOM_ALLOC   malloc
+    #define LV_MEM_CUSTOM_FREE    free
+    #define LV_MEM_CUSTOM_REALLOC realloc
+#endif     /*LV_MEM_CUSTOM*/
 
-/*Enable and configure the built-in (v)snprintf */
-#define LV_USE_BUILTIN_SNPRINTF 1
-#if LV_USE_BUILTIN_SNPRINTF
-    #define LV_SPRINTF_USE_FLOAT 0
-#endif  /*LV_USE_BUILTIN_SNPRINTF*/
+/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
+ *You will see an error log message if there wasn't enough buffers. */
+#define LV_MEM_BUF_MAX_NUM 16
 
-#define LV_STDLIB_INCLUDE <stdint.h>
-#define LV_STDIO_INCLUDE  <stdint.h>
-#define LV_STRING_INCLUDE <stdint.h>
-#define LV_MALLOC       lv_malloc_builtin
-#define LV_REALLOC      lv_realloc_builtin
-#define LV_FREE         lv_free_builtin
-#define LV_MEMSET       lv_memset_builtin
-#define LV_MEMCPY       lv_memcpy_builtin
-#define LV_SNPRINTF     lv_snprintf_builtin
-#define LV_VSNPRINTF    lv_vsnprintf_builtin
-#define LV_STRLEN       lv_strlen_builtin
-#define LV_STRNCPY      lv_strncpy_builtin
-#define LV_STRCPY       lv_strcpy_builtin
-
-#define LV_COLOR_EXTERN_INCLUDE <stdint.h>
-#define LV_COLOR_MIX      lv_color_mix
-#define LV_COLOR_PREMULT      lv_color_premult
-#define LV_COLOR_MIX_PREMULT      lv_color_mix_premult
+/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
+#define LV_MEMCPY_MEMSET_STD 0
 
 /*====================
    HAL SETTINGS
  *====================*/
 
-/*Default display refresh, input device read and animation step period.*/
-#define LV_DEF_REFR_PERIOD  33      /*[ms]*/
+/*Default display refresh period. LVG will redraw changed areas with this period time*/
+#define LV_DISP_DEF_REFR_PERIOD 30      /*[ms]*/
+
+/*Input device read period in milliseconds*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
 
 /*Use a custom tick source that tells the elapsed time in milliseconds.
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
@@ -102,82 +92,83 @@
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #define LV_DPI_DEF 130     /*[px/inch]*/
 
-/*========================
- * DRAW CONFIGURATION
- *========================*/
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
 
-/*Enable the built in mask engine.
- *Required to draw shadow, rounded corners, circles, arc, skew lines, or any other masks*/
-#define LV_USE_DRAW_MASKS 1
+/*-------------
+ * Drawing
+ *-----------*/
 
-#define LV_USE_DRAW_SW  1
-#if LV_USE_DRAW_SW
-
-    /*Enable complex draw engine.
-     *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
-    #define LV_DRAW_SW_COMPLEX 1
-
-    /* If a widget has `style_opa < 255` (not `bg_opa`, `text_opa` etc) or not NORMAL blend mode
-     * it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
-     * "Transformed layers" (if `transform_angle/zoom` are set) use larger buffers
-     * and can't be drawn in chunks. */
-
-    /*The target buffer size for simple layer chunks.*/
-    #define LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)   /*[bytes]*/
-
-    /*Used if `LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.*/
-    #define LV_DRAW_SW_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)    /*[bytes]*/
+/*Enable complex draw engine.
+ *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+#define LV_DRAW_COMPLEX 1
+#if LV_DRAW_COMPLEX != 0
 
     /*Allow buffering some shadow calculation.
-    *LV_DRAW_SW_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
-    *Caching has LV_DRAW_SW_SHADOW_CACHE_SIZE^2 RAM cost*/
-    #define LV_DRAW_SW_SHADOW_CACHE_SIZE 0
+    *LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+    *Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
+    #define LV_SHADOW_CACHE_SIZE 0
 
     /* Set number of maximally cached circle data.
     * The circumference of 1/4 circle are saved for anti-aliasing
     * radius * 4 bytes are used per circle (the most often used radiuses are saved)
     * 0: to disable caching */
-    #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
+    #define LV_CIRCLE_CACHE_SIZE 4
+#endif /*LV_DRAW_COMPLEX*/
 
-    /*Default gradient buffer size.
-     *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
-     *LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE sets the size of this cache in bytes.
-     *If the cache is too small the map will be allocated only while it's required for the drawing.
-     *0 mean no caching.*/
-    #define LV_DRAW_SW_GRADIENT_CACHE_DEF_SIZE 0
+/**
+ * "Simple layers" are used when a widget has `style_opa < 255` to buffer the widget into a layer
+ * and blend it as an image with the given opacity.
+ * Note that `bg_opa`, `text_opa` etc don't require buffering into layer)
+ * The widget can be buffered in smaller chunks to avoid using large buffers.
+ *
+ * - LV_LAYER_SIMPLE_BUF_SIZE: [bytes] the optimal target buffer size. LVGL will try to allocate it
+ * - LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE: [bytes]  used if `LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
+ *
+ * Both buffer sizes are in bytes.
+ * "Transformed layers" (where transform_angle/zoom properties are used) use larger buffers
+ * and can't be drawn in chunks. So these settings affects only widgets with opacity.
+ */
+#define LV_LAYER_SIMPLE_BUF_SIZE          (24 * 1024)
+#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)
 
-    /*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
-     *LV_DRAW_SW_GRADIENT_DITHER implies allocating one or two more lines of the object's rendering surface
-     *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
-    #define LV_DRAW_SW_GRADIENT_DITHER 0
-    #if LV_DRAW_SW_GRADIENT_DITHER
-        /*Add support for error diffusion dithering.
-         *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
-         *The increase in memory consumption is (24 bits * object's width)*/
-        #define LV_DRAW_SW_GRADIENT_DITHER_ERROR_DIFFUSION 0
-    #endif
+/*Default image cache size. Image caching keeps the images opened.
+ *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
+ *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
+ *However the opened images might consume additional RAM.
+ *0: to disable caching*/
+#define LV_IMG_CACHE_DEF_SIZE 0
 
-    /*Enable subpixel rendering*/
-    #define LV_DRAW_SW_FONT_SUBPX 1
-    #if LV_DRAW_SW_FONT_SUBPX
-        /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
-        #define LV_DRAW_SW_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
-    #endif
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS 2
+
+/*Default gradient buffer size.
+ *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+ *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
+ *If the cache is too small the map will be allocated only while it's required for the drawing.
+ *0 mean no caching.*/
+#define LV_GRAD_CACHE_DEF_SIZE 0
+
+/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
+ *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
+ *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+#define LV_DITHER_GRADIENT 0
+#if LV_DITHER_GRADIENT
+    /*Add support for error diffusion dithering.
+     *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+     *The increase in memory consumption is (24 bits * object's width)*/
+    #define LV_DITHER_ERROR_DIFFUSION 0
 #endif
 
-/*Use SDL renderer API*/
-#define LV_USE_DRAW_SDL 0
-#if LV_USE_DRAW_SDL
-    #define LV_DRAW_SDL_INCLUDE_PATH <SDL2/SDL.h>
-    /*Texture cache size, 8MB by default*/
-    #define LV_DRAW_SDL_LRU_SIZE (1024 * 1024 * 8)
-    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
-    #define LV_DRAW_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
-#endif
+/*Maximum buffer size to allocate for rotation.
+ *Only used if software rotation is enabled in the display driver.*/
+#define LV_DISP_ROT_MAX_BUF (10*1024)
 
-/*=====================
- * GPU CONFIGURATION
- *=====================*/
+/*-------------
+ * GPU
+ *-----------*/
 
 /*Use Arm's 2D acceleration library Arm-2D */
 #define LV_USE_GPU_ARM2D 0
@@ -186,17 +177,23 @@
 #define LV_USE_GPU_STM32_DMA2D 0
 #if LV_USE_GPU_STM32_DMA2D
     /*Must be defined to include path of CMSIS header of target processor
-    e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+    e.g. "stm32f7xx.h" or "stm32f4xx.h"*/
     #define LV_GPU_DMA2D_CMSIS_INCLUDE
 #endif
 
-/*Use GD32 IPA GPU
- * This adds support for Image Processing Accelerator on GD32F450 and GD32F470 series MCUs
- *
- * NOTE: IPA on GD32F450 has a bug where the fill operation overwrites data beyond the
- * framebuffer. This driver works around it by saving and restoring affected memory, but
- * this makes it not thread-safe. GD32F470 is not affected. */
-#define LV_USE_GPU_GD32_IPA 0
+/*Enable RA6M3 G2D GPU*/
+#define LV_USE_GPU_RA6M3_G2D 0
+#if LV_USE_GPU_RA6M3_G2D
+    /*include path of target processor
+    e.g. "hal_data.h"*/
+    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
+#endif
+
+/*Use SWM341's DMA2D GPU*/
+#define LV_USE_GPU_SWM341_DMA2D 0
+#if LV_USE_GPU_SWM341_DMA2D
+    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
+#endif
 
 /*Use NXP's PXP GPU iMX RTxxx platforms*/
 #define LV_USE_GPU_NXP_PXP 0
@@ -212,15 +209,15 @@
 /*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
 #define LV_USE_GPU_NXP_VG_LITE 0
 
-/*Use SWM341's DMA2D GPU*/
-#define LV_USE_GPU_SWM341_DMA2D 0
-#if LV_USE_GPU_SWM341_DMA2D
-    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+    /*Texture cache size, 8MB by default*/
+    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
+    #define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
 #endif
-
-/*=======================
- * FEATURE CONFIGURATION
- *=======================*/
 
 /*-------------
  * Logging
@@ -243,10 +240,6 @@
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
     #define LV_LOG_PRINTF 0
 
-    /*1: Enable print timestamp;
-     *0: Disable print timestamp*/
-    #define LV_LOG_USE_TIMESTAMP 1
-
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        0
     #define LV_LOG_TRACE_TIMER      0
@@ -256,7 +249,6 @@
     #define LV_LOG_TRACE_OBJ_CREATE 1
     #define LV_LOG_TRACE_LAYOUT     0
     #define LV_LOG_TRACE_ANIM       0
-	#define LV_LOG_TRACE_MSG		1
 
 #endif  /*LV_USE_LOG*/
 
@@ -287,7 +279,7 @@
 #endif
 
 /*1: Show the used memory and the memory fragmentation
- * Requires `LV_USE_BUILTIN_MALLOC = 1`*/
+ * Requires LV_MEM_CUSTOM = 0*/
 #define LV_USE_MEM_MONITOR 0
 #if LV_USE_MEM_MONITOR
     #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
@@ -296,9 +288,17 @@
 /*1: Draw random colored rectangles over the redrawn areas*/
 #define LV_USE_REFR_DEBUG 0
 
-/*Maximum buffer size to allocate for rotation.
- *Only used if software rotation is enabled in the display driver.*/
-#define LV_DISP_ROT_MAX_BUF (40*1024)
+/*Change the built in (v)snprintf functions*/
+#define LV_SPRINTF_CUSTOM 0
+#if LV_SPRINTF_CUSTOM
+    #define LV_SPRINTF_INCLUDE <stdio.h>
+    #define lv_snprintf  snprintf
+    #define lv_vsnprintf vsnprintf
+#else   /*LV_SPRINTF_CUSTOM*/
+    #define LV_SPRINTF_USE_FLOAT 0
+#endif  /*LV_SPRINTF_CUSTOM*/
+
+#define LV_USE_USER_DATA 1
 
 /*Garbage Collector settings
  *Used if lvgl is bound to higher level language and the memory is managed by that language*/
@@ -306,22 +306,6 @@
 #if LV_ENABLE_GC != 0
     #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
 #endif /*LV_ENABLE_GC*/
-
-/*Default image cache size. Image caching keeps some images opened.
- *If only the built-in image formats are used there is no real advantage of caching.
- *With other image decoders (e.g. PNG or JPG) caching save the continuous open/decode of images.
- *However the opened images consume additional RAM.
- *0: to disable caching*/
-#define LV_IMG_CACHE_DEF_SIZE 0
-
-
-/*Number of stops allowed per gradient. Increase this to allow more stops.
- *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
-#define LV_GRADIENT_MAX_STOPS 2
-
-/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
- * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
-#define LV_COLOR_MIX_ROUND_OFS 0
 
 /*=====================
  *  COMPILER SETTINGS
@@ -355,6 +339,8 @@
 /*Place performance critical functions into a faster memory (e.g RAM)*/
 #define LV_ATTRIBUTE_FAST_MEM
 
+/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
+#define LV_ATTRIBUTE_DMA
 
 /*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
  *should also appear on LVGL binding API such as Micropython.*/
@@ -417,6 +403,13 @@
 /*Enables/disables support for compressed fonts.*/
 #define LV_USE_FONT_COMPRESSED 0
 
+/*Enable subpixel rendering*/
+#define LV_USE_FONT_SUBPX 1
+#if LV_USE_FONT_SUBPX
+    /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
+    #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+#endif
+
 /*Enable drawing placeholders when glyph dsc is not found*/
 #define LV_USE_FONT_PLACEHOLDER 1
 
@@ -433,7 +426,7 @@
 #define LV_TXT_ENC LV_TXT_ENC_UTF8
 
 /*Can break (wrap) texts on these chars*/
-#define LV_TXT_BREAK_CHARS " ,.;:-_)]}"
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
 
 /*If a word is at least this long, will break wherever "prettiest"
  *To disable, set to a value <= 0*/
@@ -467,12 +460,10 @@
 #define LV_USE_ARABIC_PERSIAN_CHARS 0
 
 /*==================
- * WIDGETS
+ *  WIDGET USAGE
  *================*/
 
 /*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
-
-#define LV_USE_ANIMIMG    1
 
 #define LV_USE_ARC        1
 
@@ -481,6 +472,47 @@
 #define LV_USE_BTN        1
 
 #define LV_USE_BTNMATRIX  1
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMG        1   /*Requires: lv_label*/
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+    #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+    #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+#endif
+
+#define LV_USE_LINE       1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+#if LV_USE_ROLLER
+    #define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
+#endif
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+/*==================
+ * EXTRA COMPONENTS
+ *==================*/
+
+/*-----------
+ * Widgets
+ *----------*/
+#define LV_USE_ANIMIMG    1
 
 #define LV_USE_CALENDAR   1
 #if LV_USE_CALENDAR
@@ -496,31 +528,15 @@
     #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
 #endif  /*LV_USE_CALENDAR*/
 
-#define LV_USE_CANVAS     1
-
 #define LV_USE_CHART      1
 
-#define LV_USE_CHECKBOX   1
-
 #define LV_USE_COLORWHEEL 1
-
-#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
-
-#define LV_USE_IMG        1   /*Requires: lv_label*/
 
 #define LV_USE_IMGBTN     1
 
 #define LV_USE_KEYBOARD   1
 
-#define LV_USE_LABEL      1
-#if LV_USE_LABEL
-    #define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
-    #define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
-#endif
-
 #define LV_USE_LED        1
-
-#define LV_USE_LINE       1
 
 #define LV_USE_LIST       1
 
@@ -529,10 +545,6 @@
 #define LV_USE_METER      1
 
 #define LV_USE_MSGBOX     1
-
-#define LV_USE_ROLLER     1   /*Requires: lv_label*/
-
-#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
 
 #define LV_USE_SPAN       1
 #if LV_USE_SPAN
@@ -544,24 +556,15 @@
 
 #define LV_USE_SPINNER    1
 
-#define LV_USE_SWITCH     1
-
-#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
-#if LV_USE_TEXTAREA != 0
-    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
-#endif
-
-#define LV_USE_TABLE      1
-
 #define LV_USE_TABVIEW    1
 
 #define LV_USE_TILEVIEW   1
 
 #define LV_USE_WIN        1
 
-/*==================
- * THEMES
- *==================*/
+/*-----------
+ * Themes
+ *----------*/
 
 /*A simple, impressive and very complete theme*/
 #define LV_USE_THEME_DEFAULT 1
@@ -583,9 +586,9 @@
 /*A theme designed for monochrome displays*/
 #define LV_USE_THEME_MONO 0
 
-/*==================
- * LAYOUTS
- *==================*/
+/*-----------
+ * Layouts
+ *----------*/
 
 /*A layout similar to Flexbox in CSS.*/
 #define LV_USE_FLEX 1
@@ -593,9 +596,9 @@
 /*A layout similar to Grid in CSS.*/
 #define LV_USE_GRID 1
 
-/*====================
- * 3RD PARTS LIBRARIES
- *====================*/
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
 
 /*File system interfaces for common APIs */
 
@@ -646,34 +649,21 @@
 /*QR code library*/
 #define LV_USE_QRCODE 0
 
-/*Barcode code library*/
-#define LV_USE_BARCODE 0
-
 /*FreeType library*/
 #define LV_USE_FREETYPE 0
 #if LV_USE_FREETYPE
-    /*Memory used by FreeType to cache characters [bytes]*/
-    #define LV_FREETYPE_CACHE_SIZE (64 * 1024)
-
-    /*Let FreeType to use LVGL memory and file porting*/
-    #define LV_FREETYPE_USE_LVGL_PORT 0
-
-    /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
-    /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
-    /* if font size >= 256, must be configured as image cache */
-    #define LV_FREETYPE_SBIT_CACHE 0
-
-    /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
-    /* (0:use system defaults) */
-    #define LV_FREETYPE_CACHE_FT_FACES 4
-    #define LV_FREETYPE_CACHE_FT_SIZES 4
-#endif
-
-/* Built-in TTF decoder */
-#define LV_USE_TINY_TTF 0
-#if LV_USE_TINY_TTF
-    /* Enable loading TTF data from files */
-    #define LV_TINY_TTF_FILE_SUPPORT 0
+    /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+    #define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+    #if LV_FREETYPE_CACHE_SIZE >= 0
+        /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+        /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+        /* if font size >= 256, must be configured as image cache */
+        #define LV_FREETYPE_SBIT_CACHE 0
+        /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+        /* (0:use system defaults) */
+        #define LV_FREETYPE_CACHE_FT_FACES 0
+        #define LV_FREETYPE_CACHE_FT_SIZES 0
+    #endif
 #endif
 
 /*Rlottie library*/
@@ -687,9 +677,9 @@
     #define LV_FFMPEG_DUMP_FORMAT 0
 #endif
 
-/*==================
- * OTHERS
- *==================*/
+/*-----------
+ * Others
+ *----------*/
 
 /*1: Enable API to take snapshot for object*/
 #define LV_USE_SNAPSHOT 0
@@ -705,13 +695,6 @@
 
 /*1: Support using images as font in label or span widgets */
 #define LV_USE_IMGFONT 0
-#if LV_USE_IMGFONT
-    /*Imgfont image file path maximum length*/
-    #define LV_IMGFONT_PATH_MAX_LEN 64
-
-    /*1: Use img cache to buffer header information*/
-    #define LV_IMGFONT_USE_IMG_CACHE_HEADER 0
-#endif
 
 /*1: Enable a published subscriber based messaging system */
 #define LV_USE_MSG 0
@@ -734,38 +717,6 @@
     #endif // LV_IME_PINYIN_USE_K9_MODE
 #endif
 
-/*1: Enable file explorer*/
-/*Requires: lv_table*/
-#define LV_USE_FILE_EXPLORER                     0
-#if LV_USE_FILE_EXPLORER
-    /*Maximum length of path*/
-    #define LV_FILE_EXPLORER_PATH_MAX_LEN        (128)
-    /*Quick access bar, 1:use, 0:not use*/
-    /*Requires: lv_list*/
-    #define LV_FILE_EXPLORER_QUICK_ACCESS        1
-#endif
-
-/*==================
- * DEVICES
- *==================*/
-
-/*Use SDL to open window on PC and handle mouse and keyboard*/
-#define LV_USE_SDL              0
-#if LV_USE_SDL
-    #define LV_SDL_INCLUDE_PATH    <SDL2/SDL.h>
-    #define LV_SDL_PARTIAL_MODE    0    /*Recommended only to emulate a setup with a display controller*/
-    #define LV_SDL_FULLSCREEN      0
-#endif
-
-/*Driver for /dev/fb*/
-#define LV_USE_LINUX_FBDEV      0
-#if LV_USE_LINUX_FBDEV
-    #define LV_LINUX_FBDEV_BSD  0
-#endif
-
-/*Interface for TFT_eSPI*/
-#define LV_USE_TFT_ESPI         0
-
 /*==================
 * EXAMPLES
 *==================*/
@@ -780,7 +731,7 @@
 /*Show some widget. It might be required to increase `LV_MEM_SIZE` */
 #define LV_USE_DEMO_WIDGETS 0
 #if LV_USE_DEMO_WIDGETS
-    #define LV_DEMO_WIDGETS_SLIDESHOW 0
+#define LV_DEMO_WIDGETS_SLIDESHOW 0
 #endif
 
 /*Demonstrate the usage of encoder and keyboard*/
@@ -789,8 +740,8 @@
 /*Benchmark your system*/
 #define LV_USE_DEMO_BENCHMARK 0
 #if LV_USE_DEMO_BENCHMARK
-    /*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
-    #define LV_DEMO_BENCHMARK_RGB565A8 0
+/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
+#define LV_DEMO_BENCHMARK_RGB565A8 0
 #endif
 
 /*Stress test for LVGL*/
@@ -805,9 +756,6 @@
     #define LV_DEMO_MUSIC_LARGE     0
     #define LV_DEMO_MUSIC_AUTO_PLAY 0
 #endif
-
-/*Flex layout demo*/
-#define LV_USE_DEMO_FLEX_LAYOUT 0
 
 /*--END OF LV_CONF_H--*/
 


### PR DESCRIPTION
This PR removes dependencies on development version of `lvgl` (9.0) and restores stable 8.3 version.

Also, fixes #2.